### PR TITLE
Fix value of DecisionEvaluator being a string

### DIFF
--- a/src/DecisionEvaluator.php
+++ b/src/DecisionEvaluator.php
@@ -69,7 +69,7 @@ class DecisionEvaluator {
       $segment_id = $default_segment;
     }
 
-    return $segment_id;
+    return $segment_id ?? '';
   }
 
   /**


### PR DESCRIPTION
This change fixes a small error when segments are returning a null...

> Return value of Drupal\smart_content_cdn\DecisionEvaluator::evaluate() must be of the type string, null returned in Drupal\smart_content_cdn\DecisionEvaluator->evaluate() (line 72 of /code/modules/contrib/smart_content_cdn/src/DecisionEvaluator.php)