### PR TITLE
[EI-227] Composer install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 
 Drupal module that extends [`smart_content`](https://www.drupal.org/project/smart_content) to support Pantheon Edge Integrations and personalization features.
 
-## Usage
+## Installation
 
-For information on how to set this up, see the [Edge Integration Guide](https://pantheon.io/docs/guides/edge-integrations).
+We recommend using Composer to install this module. In your project root, run:
+
+```
+composer require pantheon-systems/smart_content_cdn
+```
+
+This will install the Smart Content module, Smart Content CDN and [`pantheon-systems/pantheon-edge-integrations`](https://github.com/pantheon-systems/pantheon-edge-integrations) -- a PHP library that is _required_ by Smart Content CDN. Smart Content CDN will not function properly without the `pantheon-edge-integrations` library.
+
+For detailed instructions on how to install and set up Smart Content CDN, see the [Edge Integration Guide](https://pantheon.io/docs/guides/edge-integrations).
 
 ## API
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "phpunit/phpunit": "^9.5",
         "drupal/coder": "^8.3"
     },
+    "suggest": {
+        "drupal/smart_content_preview": "Smart Content Preview is an optional package that allows you to preview your personalized content. It can be used with Smart Content CDN or with any Smart Content implementation."
+    },
     "scripts": {
         "lint:php": "find src/ -name '*.php' -exec php -l {} \\;",
         "lint:phpcs": "phpcs -s --standard=phpcs.ruleset.xml --extensions=php,module,inc,install,test,profile,theme .",


### PR DESCRIPTION
This PR updates the readme so that it is _explicit_ about using Composer and _requiring_ `pantheon-edge-integrations`.

It also adds a `suggest` to the `composer.json` for `smart_content_preview`.

Closes #22