### PR TITLE
The project has moved to Drupal.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Smart Content CDN
 
+Moved to [Drupal.org Smart Content CDN](https://www.drupal.org/project/smart_content_cdn).
+
 [![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#unsupported) ![Build Status](https://github.com/pantheon-systems/smart_content_cdn/actions/workflows/main.yml/badge.svg) ![Package Version](https://img.shields.io/packagist/v/pantheon-systems/smart_content_cdn)
 
 Drupal module that extends [`smart_content`](https://www.drupal.org/project/smart_content) to support Pantheon Edge Integrations and personalization features.


### PR DESCRIPTION
https://www.drupal.org/project/smart_content_cdn

We should probably set this project as an archive project so people don't accidentally install it instead. Make sure people use https://www.drupal.org/project/smart_content_cdn .